### PR TITLE
Add CatBoostClassifier/CatBoostRegressor Docs & Fix badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # CatBoost.jl
 
-[![Build Status][build-img]][build-url] [![CodeCov][codecov-img]][codecov-url] [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://beacon-biosignals.github.io/CatBoost.jl/dev)
+[![Build Status][build-img]][build-url] [![CodeCov][codecov-img]][codecov-url] [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaAI.github.io/CatBoost.jl/dev)
 
-[build-img]: https://github.com/beacon-biosignals/CatBoost.jl/workflows/CI/badge.svg
-[build-url]: https://github.com/beacon-biosignals/CatBoost.jl/actions
-[codecov-img]: https://codecov.io/gh/beacon-biosignals/CatBoost.jl/branch/main/graph/badge.svg?token=e4RFBNkB9a
-[codecov-url]: https://codecov.io/github/beacon-biosignals/CatBoost.jl
+[build-img]: https://github.com/JuliaAI/CatBoost.jl/workflows/CI/badge.svg
+[build-url]: https://github.com/JuliaAI/CatBoost.jl/actions
+[codecov-img]: https://codecov.io/gh/JuliaAI/CatBoost.jl/branch/main/graph/badge.svg?token=e4RFBNkB9a
+[codecov-url]: https://codecov.io/github/JuliaAI/CatBoost.jl
 
 
 Julia interface to [CatBoost](https://catboost.ai/).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [build-img]: https://github.com/JuliaAI/CatBoost.jl/workflows/CI/badge.svg
 [build-url]: https://github.com/JuliaAI/CatBoost.jl/actions
-[codecov-img]: https://codecov.io/gh/JuliaAI/CatBoost.jl/branch/main/graph/badge.svg?token=e4RFBNkB9a
+[codecov-img]: https://codecov.io/gh/JuliaAI/CatBoost.jl/branch/main/graph/badge.svg
 [codecov-url]: https://codecov.io/github/JuliaAI/CatBoost.jl
 
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,5 +5,5 @@ makedocs(; modules=[CatBoost], sitename="CatBoost.jl", authors="Beacon Biosignal
          pages=["Introduction" => "index.md", "Wrapper" => "wrapper.md",
                 "MLJ API" => "mlj_api.md"])
 
-deploydocs(; repo="github.com/beacon-biosignals/CatBoost.jl.git", push_preview=true,
+deploydocs(; repo="github.com/JuliaAI/CatBoost.jl.git", push_preview=true,
            devbranch="main")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,5 +5,4 @@ makedocs(; modules=[CatBoost], sitename="CatBoost.jl", authors="Beacon Biosignal
          pages=["Introduction" => "index.md", "Wrapper" => "wrapper.md",
                 "MLJ API" => "mlj_api.md"])
 
-deploydocs(; repo="github.com/JuliaAI/CatBoost.jl.git", push_preview=true,
-           devbranch="main")
+deploydocs(; repo="github.com/JuliaAI/CatBoost.jl.git", push_preview=true, devbranch="main")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,7 +2,7 @@
 
 Julia interface to [CatBoost](https://catboost.ai/). This library is a wrapper CatBoost's Python package via [PythonCall.jl](https://github.com/cjdoris/PythonCall.jl). 
 
-For a nice introduction to the package, see the [examples](https://github.com/beacon-biosignals/CatBoost.jl/blob/main/examples/).
+For a nice introduction to the package, see the [examples](https://github.com/JuliaAI/CatBoost.jl/blob/main/examples/).
 
 # Installation
 

--- a/src/CatBoost.jl
+++ b/src/CatBoost.jl
@@ -39,11 +39,11 @@ function __init__()
     cv
 
     @doc """
-    Pool(data; label=nothing, cat_features=nothing, text_features=nothing,
-            pairs=nothing, delimiter='\t', has_header=false, weight=nothing,
-            group_id = nothing, group_weight=nothing, subgroup_id=nothing,
-            pairs_weight=nothing, baseline=nothing, features_names=nothing,
-            thread_count = -1) -> Py
+        Pool(data; label=nothing, cat_features=nothing, text_features=nothing,
+                pairs=nothing, delimiter='\t', has_header=false, weight=nothing,
+                group_id = nothing, group_weight=nothing, subgroup_id=nothing,
+                pairs_weight=nothing, baseline=nothing, features_names=nothing,
+                thread_count = -1) -> Py
 
     Creates a `Pool` object holding training data and labels. `data` may also be passed
     as a keyword argument.
@@ -55,6 +55,32 @@ function __init__()
     $(@doc catboost.Pool)
     """
     Pool
+
+    @doc """
+        CatBoostClassifier(args...; kwargs...) -> Py
+
+    Creates a `CatBoostClassifier` object.
+
+    ---
+
+    ## Python documentation for `catboost.CatBoostClassifier`
+
+    $(@doc catboost.CatBoostClassifier)
+    """
+    CatBoostClassifier
+
+    @doc """
+        CatBoostRegressor(args...; kwargs...) -> Py
+
+    Creates a `CatBoostRegressor` object.
+
+    ---
+
+    ## Python documentation for `catboost.CatBoostRegressor`
+
+    $(@doc catboost.CatBoostRegressor)
+    """
+    CatBoostRegressor
 
     return nothing
 end

--- a/src/MLJCatBoostInterface.jl
+++ b/src/MLJCatBoostInterface.jl
@@ -169,8 +169,8 @@ end
 
 MMI.metadata_pkg.((CatBoostClassifier, CatBoostRegressor), name="CatBoost.jl",
                   package_uuid="e2e10f9a-a85d-4fa9-b6b2-639a32100a12",
-                  package_url="https://github.com/JuliaAI/CatBoost.jl",
-                  is_pure_julia=false, package_license="MIT")
+                  package_url="https://github.com/JuliaAI/CatBoost.jl", is_pure_julia=false,
+                  package_license="MIT")
 
 MMI.metadata_model(CatBoostClassifier;
                    input_scitype=Union{MMI.Table(MMI.Continuous, MMI.Count,

--- a/src/MLJCatBoostInterface.jl
+++ b/src/MLJCatBoostInterface.jl
@@ -169,7 +169,7 @@ end
 
 MMI.metadata_pkg.((CatBoostClassifier, CatBoostRegressor), name="CatBoost.jl",
                   package_uuid="e2e10f9a-a85d-4fa9-b6b2-639a32100a12",
-                  package_url="https://github.com/beacon-biosignals/CatBoost.jl",
+                  package_url="https://github.com/JuliaAI/CatBoost.jl",
                   is_pure_julia=false, package_license="MIT")
 
 MMI.metadata_model(CatBoostClassifier;

--- a/test/mlj_interface.jl
+++ b/test/mlj_interface.jl
@@ -50,7 +50,13 @@
         end
         @testset "CatBoostClassifier" begin
             for data in [MLJTestInterface.make_binary(), MLJTestInterface.make_multiclass()]
-                failures, summary = MLJTestInterface.test([CatBoostClassifier], data...;
+                X = data[1]
+                y = data[2]
+                # catboost fails if only 1 class is present when training
+                # MLJTestInterface splits the data down the middle, so the binary
+                # data only has one class during training
+                y[1] = y[end]
+                failures, summary = MLJTestInterface.test([CatBoostClassifier], X, y;
                                                           mod=@__MODULE__, verbosity=0, # bump to debug
                                                           throw=false)
                 @test isempty(failures)


### PR DESCRIPTION
I added documentation for the python CatBoostClassifier/CatBoostRegressor models. Additionally, the beacon-biosignals links were updated with JuliaAI, so hopefully, all the badges will work again. 

https://github.com/JuliaAI/CatBoost.jl/issues/19