### PR TITLE
Add macos CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,6 +37,9 @@ jobs:
           - os: windows-latest
             version: '1'
             arch: x64
+          - os: macos-latest
+            version: '1'
+            arch: x64
     env:
       PYTHON: ''
     steps:


### PR DESCRIPTION
Added a CI run for macos to detect issues.

Inspired by https://github.com/OutlierDetectionJL/OutlierDetectionPython.jl/pull/3/commits/6c89a7c263c8342df9fa81d767395978b1e5c51b, where I found out about numba imports causing segfaults on mac, and needing to be statically linked. 