### PR TITLE
Update catboost version to `>=1.1`

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,3 +1,3 @@
 [deps.catboost]
 channel = "conda-forge"
-version = "=1.1"
+version = ">=1.1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CatBoost"
 uuid = "e2e10f9a-a85d-4fa9-b6b2-639a32100a12"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"

--- a/README.md
+++ b/README.md
@@ -58,3 +58,14 @@ preds = predict(model, eval_data)
 
 end # module
 ```
+
+# Restricting Python catboost version
+
+By default, `CatBoost.jl` installs the latest compatible version of `catboost` (version `>=1.1`) in your current `CondaPkg.jl` environment. To install a specific version, create a `CondaPkg.toml` file using `CondaPkg.jl`. Below is an example for specifying `catboost` version `v1.1`:
+
+```julia
+using CondaPkg
+CondaPkg.add("catboost"; version="=1.1")
+```
+
+This will create a `CondaPkg.toml` file in your current envrionment with the restricted `catboost` version. More details about managing conda environments with `CondaPkg.jl` can be found [here](https://github.com/cjdoris/CondaPkg.jl).

--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ using CondaPkg
 CondaPkg.add("catboost"; version="=1.1")
 ```
 
-This will create a `CondaPkg.toml` file in your current envrionment with the restricted `catboost` version. More details about managing conda environments with `CondaPkg.jl` can be found [here](https://github.com/cjdoris/CondaPkg.jl).
+This will create a `CondaPkg.toml` file in your current envrionment with the restricted `catboost` version. For more information on managing Conda environments with `CondaPkg.jl`, refer to the [official documentation](https://github.com/cjdoris/CondaPkg.jl).


### PR DESCRIPTION
Catboost `v1.2` was recently released, and it comes with Python 3.11 support. Here are the full release notes: https://github.com/catboost/catboost/releases/tag/v1.2

