### PR TITLE
fix UndefVarError in update method

### DIFF
--- a/src/MLJCatBoostInterface.jl
+++ b/src/MLJCatBoostInterface.jl
@@ -144,6 +144,7 @@ function MMI.update(mlj_model::CatBoostModels, verbosity::Integer, fitresult, ca
     if mlj_model.iterations > cache.mlj_model.iterations &&
        MMI.is_same_except(mlj_model, cache.mlj_model, :iterations)
         iterations = mlj_model.iterations - cache.mlj_model.iterations
+        verbose = verbosity <= 1 ? false : true
         new_model = model_init(mlj_model; verbose, iterations)
         new_model.fit(data_pool; init_model=fitresult)
         report = (feature_importances=feature_importance(new_model),)


### PR DESCRIPTION
While running some mlj integration tests. I discovered an error in the `update` method. So this PR fixes this. 
cc. @ablaom 