### PR TITLE
Fix example in docs, match docs with README, add downgrade check 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,6 @@ jobs:
             arch: x64
           - os: macos-latest
             version: '1'
-            arch: x64
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,28 @@
+name: Downgrade
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ['1']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+      - uses: cjdoris/julia-downgrade-compat-action@v1
+        with:
+          skip: Pkg,TOML
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
   Documentation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
           version: 1.6 # earliest supported version

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: 1.6.0
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Instantiate `format` environment and format
         run: |
           julia  --project=format -e 'using Pkg; Pkg.instantiate()'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CatBoost"
 uuid = "e2e10f9a-a85d-4fa9-b6b2-639a32100a12"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
@@ -10,14 +10,14 @@ PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-Aqua = "0.8"
+Aqua = "0.8.4"
 DataFrames = "1.6"
 MLJBase = "1"
-MLJModelInterface = "1"
-MLJTestInterface = "0.2"
-OrderedCollections = "1.4"
+MLJModelInterface = "1.7"
+MLJTestInterface = "0.2.6"
+OrderedCollections = "1.6"
 PythonCall = "0.9"
-Tables = "1.4"
+Tables = "1.10"
 Test = "1.6"
 julia = "1.6"
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,21 @@
 [codecov-url]: https://codecov.io/github/JuliaAI/CatBoost.jl
 
 
-Julia interface to [CatBoost](https://catboost.ai/).
+Julia interface to [CatBoost](https://catboost.ai/). This library is a wrapper CatBoost's Python package via [PythonCall.jl](https://github.com/cjdoris/PythonCall.jl). 
+
+For a nice introduction to the package, see the [examples](https://github.com/JuliaAI/CatBoost.jl/blob/main/examples/).
+
+# Installation
+
+This package is available in the Julia General Registry. You can install it with either of the following commands:
+
+```
+pkg> add CatBoost
+```
+
+```julia
+julia> using Pkg; Pkg.add("CatBoost")
+```
 
 ## Example
 
@@ -38,7 +52,7 @@ end # module
 ```julia
 module Regression
 
-using CatBoost
+using CatBoost.MLJCatBoostInterface
 using DataFrames
 using MLJBase
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,3 +15,63 @@ pkg> add CatBoost
 ```julia
 julia> using Pkg; Pkg.add("CatBoost")
 ```
+
+## Example
+
+```julia
+module Regression
+
+using CatBoost
+using PythonCall
+
+train_data = PyList([[1, 4, 5, 6], [4, 5, 6, 7], [30, 40, 50, 60]])
+eval_data = PyList([[2, 4, 6, 8], [1, 4, 50, 60]])
+train_labels = PyList([10, 20, 30])
+
+# Initialize CatBoostRegressor
+model = CatBoostRegressor(iterations = 2, learning_rate = 1, depth = 2)
+
+# Fit model
+fit!(model, train_data, train_labels)
+
+# Get predictions
+preds = predict(model, eval_data)
+
+end # module
+```
+
+## MLJ Example
+```julia
+module Regression
+
+using CatBoost.MLJCatBoostInterface
+using DataFrames
+using MLJBase
+
+train_data = DataFrame([[1,4,30], [4,5,40], [5,6,50], [6,7,60]], :auto)
+eval_data = DataFrame([[2,1], [4,4], [6,50], [8,60]], :auto)
+train_labels = [10.0, 20.0, 30.0] 
+
+# Initialize MLJ Machine
+model = CatBoostRegressor(iterations = 2, learning_rate = 1, depth = 2)
+mach = machine(model, train_data, train_labels)
+
+# Fit model
+MLJBase.fit!(mach)
+
+# Get predictions
+preds = predict(model, eval_data)
+
+end # module
+```
+
+# Restricting Python catboost version
+
+By default, `CatBoost.jl` installs the latest compatible version of `catboost` (version `>=1.1`) in your current `CondaPkg.jl` environment. To install a specific version, create a `CondaPkg.toml` file using `CondaPkg.jl`. Below is an example for specifying `catboost` version `v1.1`:
+
+```julia
+using CondaPkg
+CondaPkg.add("catboost"; version="=1.1")
+```
+
+This will create a `CondaPkg.toml` file in your current envrionment with the restricted `catboost` version. For more information on managing Conda environments with `CondaPkg.jl`, refer to the [official documentation](https://github.com/cjdoris/CondaPkg.jl).


### PR DESCRIPTION
Fixed the example in the README and expanded the README/docs homepage to match each other. 

I added a Downgrade action that checks the minimum bounds on all the compat entries (and fixed all the issues that came up). 

I also dropped the x64 arch for mac to prepare for when the arm runners become the default. 
