### PR TITLE
Fix MLJ example in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,19 +56,20 @@ using CatBoost.MLJCatBoostInterface
 using DataFrames
 using MLJBase
 
-train_data = DataFrame([[1,4,30], [4,5,40], [5,6,50], [6,7,60]], :auto)
-eval_data = DataFrame([[2,1], [4,4], [6,50], [8,60]], :auto)
-train_labels = [10.0, 20.0, 30.0] 
+# Initialize data
+train_data = DataFrame([[1, 4, 30], [4, 5, 40], [5, 6, 50], [6, 7, 60]], :auto)
+train_labels = [10.0, 20.0, 30.0]
+eval_data = DataFrame([[2, 1], [4, 4], [6, 50], [8, 60]], :auto)
 
-# Initialize MLJ Machine
-model = CatBoostRegressor(iterations = 2, learning_rate = 1, depth = 2)
+# Initialize CatBoostClassifier
+model = CatBoostRegressor(; iterations=2, learning_rate=1.0, depth=2)
 mach = machine(model, train_data, train_labels)
 
 # Fit model
 MLJBase.fit!(mach)
 
 # Get predictions
-preds = predict(model, eval_data)
+preds_class = MLJBase.predict(mach, eval_data)
 
 end # module
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -48,19 +48,20 @@ using CatBoost.MLJCatBoostInterface
 using DataFrames
 using MLJBase
 
-train_data = DataFrame([[1,4,30], [4,5,40], [5,6,50], [6,7,60]], :auto)
-eval_data = DataFrame([[2,1], [4,4], [6,50], [8,60]], :auto)
-train_labels = [10.0, 20.0, 30.0] 
+# Initialize data
+train_data = DataFrame([[1, 4, 30], [4, 5, 40], [5, 6, 50], [6, 7, 60]], :auto)
+train_labels = [10.0, 20.0, 30.0]
+eval_data = DataFrame([[2, 1], [4, 4], [6, 50], [8, 60]], :auto)
 
-# Initialize MLJ Machine
-model = CatBoostRegressor(iterations = 2, learning_rate = 1, depth = 2)
+# Initialize CatBoostClassifier
+model = CatBoostRegressor(; iterations=2, learning_rate=1.0, depth=2)
 mach = machine(model, train_data, train_labels)
 
 # Fit model
 MLJBase.fit!(mach)
 
 # Get predictions
-preds = predict(model, eval_data)
+preds_class = MLJBase.predict(mach, eval_data)
 
 end # module
 ```

--- a/examples/mlj/binary.jl
+++ b/examples/mlj/binary.jl
@@ -3,7 +3,6 @@ module Binary
 using CatBoost.MLJCatBoostInterface
 using DataFrames
 using MLJBase
-using PythonCall
 
 # Initialize data
 train_data = DataFrame([coerce(["a", "a", "c"], Multiclass),

--- a/examples/mlj/multiclass.jl
+++ b/examples/mlj/multiclass.jl
@@ -3,7 +3,6 @@ module Multiclass
 using CatBoost.MLJCatBoostInterface
 using DataFrames
 using MLJBase
-using PythonCall
 
 # Initialize data
 train_data = DataFrame([coerce(["a", "a", "c"], MLJBase.Multiclass),

--- a/examples/mlj/regression.jl
+++ b/examples/mlj/regression.jl
@@ -3,7 +3,6 @@ module Regression
 using CatBoost.MLJCatBoostInterface
 using DataFrames
 using MLJBase
-using PythonCall
 
 # Initialize data
 train_data = DataFrame([[1, 4, 30], [4, 5, 40], [5, 6, 50], [6, 7, 60]], :auto)


### PR DESCRIPTION
Ref #32

I somehow did not commit the change to update the README.md example (the main reason I opened the previous PR). This should fix it. I apologize for the sloppiness. 


```julia
julia> module Regression

       using CatBoost.MLJCatBoostInterface
       using DataFrames
       using MLJBase

       # Initialize data
       train_data = DataFrame([[1, 4, 30], [4, 5, 40], [5, 6, 50], [6, 7, 60]], :auto)
       train_labels = [10.0, 20.0, 30.0]
       eval_data = DataFrame([[2, 1], [4, 4], [6, 50], [8, 60]], :auto)

       # Initialize CatBoostClassifier
       model = CatBoostRegressor(; iterations=2, learning_rate=1.0, depth=2)
       mach = machine(model, train_data, train_labels)

       # Fit model
       MLJBase.fit!(mach)

       # Get predictions
       preds_class = MLJBase.predict(mach, eval_data)

       end # module
WARNING: replacing module Regression.
[ Info: Training machine(CatBoostRegressor(iterations = 2, …), …).
Main.Regression
```
