### PR TITLE
CatBoostRegressor.subsample should be Float64

### DIFF
--- a/src/mlj_catboostregressor.jl
+++ b/src/mlj_catboostregressor.jl
@@ -44,7 +44,7 @@ MMI.@mlj_model mutable struct CatBoostRegressor <: MMI.Deterministic
     task_type::Union{String,Nothing} = nothing
     devices::Union{String,Nothing} = nothing
     bootstrap_type::Union{String,Nothing} = nothing
-    subsample::Union{Int,Nothing} = nothing
+    subsample::Union{Float64,Nothing} = nothing
     sampling_frequency::String = "PerTreeLevel"::(_ in ("PerTree", "PerTreeLevel"))
     sampling_unit::String = "Object"::(_ in ("Group", "Object"))
     gpu_cat_features_storage::String = "GpuRam"::(_ in ("CpuPinnedMemory", "GpuRam"))


### PR DESCRIPTION
According to CatBoost doc, it should be a floating number in the range (0, 1].

The proof is if you set an integer larger than 1 to `subsample` and train, you will get the error:
```
Python: CatBoostError: /src/catboost/catboost/private/libs/options/bootstrap_options.cpp:5: Subsample should be in (0,1]
```