### PR TITLE
Restrict `numpy<2` and bump actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,11 +44,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1 # https://github.com/julia-actions/cache
+      - uses: julia-actions/cache@v2 # https://github.com/julia-actions/cache
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/julia-downgrade-compat-action@v1
+      - uses: julia-actions/julia-downgrade-compat@v1
         with:
           skip: Pkg,TOML
       - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -18,10 +18,10 @@ jobs:
         version: ['1']
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-      - uses: cjdoris/julia-downgrade-compat-action@v1
+      - uses: julia-actions/julia-downgrade-compat-action@v1
         with:
           skip: Pkg,TOML
       - uses: julia-actions/julia-buildpkg@v1

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,3 +1,3 @@
-[deps.catboost]
-channel = "conda-forge"
-version = ">=1.1"
+[deps]
+numpy = ">=1,<2"
+catboost = ">=1.1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CatBoost"
 uuid = "e2e10f9a-a85d-4fa9-b6b2-639a32100a12"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"


### PR DESCRIPTION
Ref https://github.com/JuliaAI/CatBoost.jl/issues/37

I also went ahead and bumped the actions to prevent issues down the road (since this library is less actively developed).