### PR TITLE
Remove nightly from ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,6 @@ jobs:
         version:
           - '1.6'
           - '1' 
-          - 'nightly'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
These tests mess up the pass/fail reporting and have negligible impact on development, as far as I can see. There is some agreement about this position [here](https://discourse.julialang.org/t/why-do-packages-run-continuous-integration-tests-on-julia-nightly/101208/49?u=ablaom).